### PR TITLE
Remove unnecessary block request and sleep

### DIFF
--- a/lib/unfollower.rb
+++ b/lib/unfollower.rb
@@ -50,7 +50,6 @@ class Unfollower
         puts "#{f.screen_name}"
         puts "\tCreated #{f.created_at} :: #{f.description} :: #{f.website}"
         io.write "#{f.screen_name}\n"
-        sleep(1)
       end
     end
   rescue StandardError => e

--- a/lib/unfollower.rb
+++ b/lib/unfollower.rb
@@ -29,8 +29,11 @@ class Unfollower
     throw 'Not an array.' if assholes.class != Array
     assholes.each do |asshole|
       puts "Blocking #{asshole} ..."
-      @client.report_spam(asshole) if report_spam
-      @client.block(asshole)
+      if report_spam
+        @client.report_spam(asshole)
+      else
+        @client.block(asshole)
+      end
       sleep(2)
     end
   rescue StandardError => e


### PR DESCRIPTION
`report_spam` method also blocks user:  
https://dev.twitter.com/rest/reference/post/users/report_spam

And since the followers requested all at once, there is no need to sleep in between each one (unless the sleep was intended for the user to read each follower one second at a time).
